### PR TITLE
Fix haddock freeze empty opt p response file

### DIFF
--- a/haskell/private/actions/compile.bzl
+++ b/haskell/private/actions/compile.bzl
@@ -232,16 +232,7 @@ def _compilation_defaults(hs, cc, java, posix, dep_info, plugin_dep_info, srcs, 
             idir = import_dir_map[s]
             set.mutable_insert(import_dirs, idir)
 
-    # Write the -optP flags to a parameter file because they can be very long on Windows
-    # e.g. 27Kb for grpc-haskell
-    # Equivalent to: compile_flags += ["-optP" + f for f in cc.cpp_flags]
-    optp_args_file = hs.actions.declare_file("optp_args_%s" % hs.name)
-    optp_args = hs.actions.args()
-    optp_args.add_all(cc.cpp_flags)
-    optp_args.set_param_file_format("multiline")
-    hs.actions.write(optp_args_file, optp_args)
-    compile_flags += ["-optP@" + optp_args_file.path]
-
+    compile_flags += ["-optP" + f for f in cc.cpp_flags]
     compile_flags += cc.include_args
 
     # This is absolutely required otherwise GHC doesn't know what package it's
@@ -328,7 +319,6 @@ def _compilation_defaults(hs, cc, java, posix, dep_info, plugin_dep_info, srcs, 
             extra_srcs,
             header_files,
             pkg_info_inputs,
-            depset([optp_args_file]),
         ],
     )
 

--- a/haskell/repositories.bzl
+++ b/haskell/repositories.bzl
@@ -6,9 +6,6 @@ load(":private/versions.bzl", "check_version")
 
 def rules_haskell_dependencies():
     """Provide all repositories that are necessary for `rules_haskell` to function."""
-    if "bazel_version" in dir(native):
-        check_version(native.bazel_version)
-
     maybe(
         http_archive,
         name = "platforms",


### PR DESCRIPTION
This MR contains two commits:

- Replace the usage of response file (i.e. indirect file containing flags) by direct use of command line flags for `-optP`. In some context (see https://gitlab.haskell.org/ghc/ghc/-/issues/18177), it breaks our haddock generation which freeze indefinitily.
- Remove the bazel version check, we check that our bazel version works fine enough with our version of rules_haskell, the warning was just generating confusion for our developers.